### PR TITLE
Fix tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.2"
 # command to install dependencies
 install:
+  - git config --global user.email "auto-version-test@travis.ci"
+  - git config --global user.name "Testing on Travis CI"
   - pip install . --use-mirrors
   - pip install -r requirements.txt --use-mirrors
 # command to run tests


### PR DESCRIPTION
Error was:

2013-02-27 14:36:11,509 - auto_version - INFO - executing command: git add testfile1.txt testfile2.txt

**\* Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.
# 
## ERROR: test_perform (tests.parsers_test.TestBasicParser)

Traceback (most recent call last):
  File "/home/travis/build/paulollivier/auto_versionning/tests/parsers_test.py", line 48, in test_perform
    self.assertEqual("0.1", self.p.perform())
  File "/home/travis/build/paulollivier/auto_versionning/auto_version/parsers.py", line 115, in perform
    self.vcs.set_version(files=self.files, version=new_version, prefix=self.scm_prefix)
  File "/home/travis/build/paulollivier/auto_versionning/auto_version/dvcs.py", line 130, in set_version
    check_call(["git", "commit", "-m", "auto_version: added files for whom version has changed."])
  File "/usr/lib/python2.7/subprocess.py", line 511, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['git', 'commit', '-m', 'auto_version: added files for whom version has changed.']' returned non-zero exit status 128
