### PR TITLE
install to 'auto-version'

### DIFF
--- a/auto_version/main.py
+++ b/auto_version/main.py
@@ -8,7 +8,7 @@ import logging
 from auto_version.utils import ConfManager, logger
 from auto_version.parsers import BasicParser
 
-if __name__ == '__main__':
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('action', default=None, help="The action to perform, eg. increment 'build', 'patch', 'rev' ... Please see documentation for full list")
     parser.add_argument('--files', '-f', nargs="+", help="the file[s] to check for version string[s]")
@@ -44,4 +44,7 @@ if __name__ == '__main__':
         del conf["conf"]
         cf.save_conf(conf)
     except:
-        logger.exception("Something went wrong! Please report the following info, go to https///github.com/paulollivier/auto_versioning, and fill in an issue.")
+        logger.exception("Something went wrong! Please report the following info, go to https://github.com/paulollivier/auto_versionning, and fill in an issue.")
+
+if __name__ == '__main__':
+    main()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import os
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-from increment_version import __version__
+from auto_version.main import __version__
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Here is the one used for this module:
 .. code:: json
 
     {
-        "files": "increment_version.py",
+        "files": "auto_version/main.py",
         "current_version": "0.1.0",
         "style": "Triplet"
     }
@@ -68,7 +68,7 @@ VCS Integration
 
     This is still a rather unstable feature, your workflow may be changed, and possibly destroyed.
 
-If versioning system is detected (via the presence or not of a distinctive versioning directory, like ``.git``), ``increment_version.py`` uses the informations present in the SCM to determine the version numbers. For git, it is via the ``git tag`` and ``git describe`` commands;
+If versioning system is detected (via the presence or not of a distinctive versioning directory, like ``.git``), ``auto-version`` uses the informations present in the SCM to determine the version numbers. For git, it is via the ``git tag`` and ``git describe`` commands;
 
 This still requires a ``version.conf`` file, but only three parameters are used::
 
@@ -91,17 +91,17 @@ Sample Usage
     $ git add hello.txt version.conf
     $ git commit -m "Initial commit"
     $ git tag 0.0.1
-    $ increment_version.py update
+    $ auto-version update
     $ cat hello.txt
     0.0.1
     $ echo "hi\!" >> hello.txt
     $ git add hello.txt
     $ git commit -m "Modified hello.txt to better reflect my understanding of the world, from a programmer\'s perspective"
-    $ increment_version.py update
+    $ auto-version update
     $ cat hello.txt
     0.0.2-pre1-0bf45de
     hi!
-    $ increment_version.py patch
+    $ auto-version patch
     $ cat hello.txt
     0.0.2
     hi!

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,24 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from increment_version import __version__
+from auto_version.main import __version__
 
 setup(
     name='auto-version',
     version=__version__,
     author='Paul Ollivier',
     author_email='contact@paulollivier.fr',
-    scripts=['increment_version.py'],
     url='https://github.com/paulollivier/auto_versionning',
     license=open('LICENSE.txt', 'r').read(),
     packages=['auto_version'],
     description='A not-so-simple versioning semi-automation.',
     long_description=open('README.rst', 'r').read(),
     requires=["argparse"],
+    entry_points={
+      'console_scripts': [
+          'auto-version = auto_version.main:main',
+          ]
+      },
     classifiers=(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/version.conf
+++ b/version.conf
@@ -1,5 +1,5 @@
 {
     "current_version": "0.1.3",
-    "files": "increment_version.py",
+    "files": "auto_version/main.py",
     "style": "Triplet"
 }


### PR DESCRIPTION
This installs the command line interface to 'auto-version' instead of to 'increment_version.py'. That should create less confusion.

Also, would you be willing to move this very git repository from https://github.com/paulollivier/auto_versionning to https://github.com/paulollivier/auto-version to match the name on PyPI ?
